### PR TITLE
Fix IndexError

### DIFF
--- a/dreamberd/builtin.py
+++ b/dreamberd/builtin.py
@@ -117,7 +117,7 @@ class DreamberdList(DreamberdIndexable, DreamberdNamespaceable, DreamberdMutable
             raise NonFormattedError("Cannot index a list with a non-number value.")
         if not is_int(index.value):
             raise NonFormattedError("Expected integer for list indexing.")
-        elif not -1 <= index.value <= len(self.values) - 1:
+        elif not -1 <= index.value <= len(self.values) - 2:
             raise NonFormattedError("Indexing out of list bounds.")
         return self.values[round(index.value) + 1]
 


### PR DESCRIPTION
The following code:
```java
const const a = [2, 4, 8]!
a[2]?
```
Crashes with `IndexError: list index out of range`.
This PR would fix that.