### PR TITLE
Fix after-statements

### DIFF
--- a/dreamberd/interpreter.py
+++ b/dreamberd/interpreter.py
@@ -1193,14 +1193,14 @@ def execute_after_statement(event: Value, statements_inside_scope: list[tuple[Co
             def on_release(key: Optional[Union[keyboard.Key, keyboard.KeyCode]]):
                 nonlocal namespaces, statements_inside_scope
                 if key in keys:
-                    interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_keyboard_event_object(key, event.value))}], [], when_statement_watchers + [{}])
+                    interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_keyboard_event_object(key.char if isinstance(key, keyboard.KeyCode) else key, event.value))}], [], when_statement_watchers + [{}])
                 keys.discard(key)
             listener = keyboard.Listener(on_press=on_press, on_release=on_release)  # type: ignore
 
         case "keydown":
             def on_press(key: Optional[Union[keyboard.Key, keyboard.KeyCode]]):
                 nonlocal namespaces, statements_inside_scope
-                interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_keyboard_event_object(key, event.value))}], [], when_statement_watchers + [{}])
+                interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_keyboard_event_object(key.char if isinstance(key, keyboard.KeyCode) else key, event.value))}], [], when_statement_watchers + [{}])
             listener = keyboard.Listener(on_press=on_press)  # type: ignore
 
         case "keyup":

--- a/dreamberd/interpreter.py
+++ b/dreamberd/interpreter.py
@@ -1204,11 +1204,10 @@ def execute_after_statement(event: Value, statements_inside_scope: list[tuple[Co
             listener = keyboard.Listener(on_press=on_press)  # type: ignore
 
         case "keyup":
-            def listener_func(x: int, y: int, button: mouse.Button, pressed: bool):
-                nonlocal namespaces, statements_inside_scope
-                if not pressed:
-                    interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_mouse_event_object(x, y, button, event.value))}], [], when_statement_watchers + [{}])
-            listener = keyboard.Listener(on_click=listener_func)  # type: ignore
+            def on_release(key: Optional[Union[keyboard.Key, keyboard.KeyCode]]):
+                nonlocal namespaces, statements_inside_scope
+                interpret_code_statements(statements_inside_scope, namespaces + [{'event': Name('event', get_keyboard_event_object(key.char if isinstance(key, keyboard.KeyCode) else key, event.value))}], [], when_statement_watchers + [{}])
+            listener = keyboard.Listener(on_release=on_release)  # type: ignore
 
         case _:
             raise_error_at_line(filename, code, current_line, f"Invalid event for the \"after\" statement: \"{db_to_string(event)}\"")


### PR DESCRIPTION
Currently running the following code and pressing `a`:
```java
after "keydown" {
   event.key?
   event.key == "a"?
}
```
will result in
```
__unnamed_file__, line 2

     event.key?
     ^^^^^^^^^
Expression evaluates to value 'a'.


__unnamed_file__, line 3

     event.key == "a"?
     ^^^^^^^^^
Expression evaluates to value false.
```

This is because `event.key` is a string with the 3 characters `'a'` (*including* the quotes). This PR would fix this.

This PR also fixes `keyup`.