### PR TITLE
Fix list indexing

### DIFF
--- a/dreamberd/builtin.py
+++ b/dreamberd/builtin.py
@@ -122,7 +122,7 @@ class DreamberdList(DreamberdIndexable, DreamberdNamespaceable, DreamberdMutable
     def __post_init__(self):
         self.create_namespace(False)
         self.indexer = dict()
-        for index in range(len(self.values)):
+        for index in range(-1, len(self.values)-1):
             self.indexer[index] = index
 
     def create_namespace(self, is_update: bool = True) -> None:


### PR DESCRIPTION
Originally the indexes were the normal 0 to `len()-1`. This caused `-1` to issue a dreamberd error and a call to `len()-1` caused a python error instead of a dreamberd one. This fixes both.

Closes https://github.com/vivaansinghvi07/dreamberd-interpreter/issues/28.