### PR TITLE
Ensure that execution finished message is shown.

### DIFF
--- a/dreamberd/__init__.py
+++ b/dreamberd/__init__.py
@@ -103,7 +103,7 @@ def run_file(main_filename: str) -> None:  # idk what else to call this
                 importable_names[target_filename] = {}
             importable_names[target_filename][name] = value
 
-    print("\033[33mCode has finished executing. Press ^C once or twice to stop waiting for when-statements and after-statements.\033[039m")
+    print("\033[33mCode has finished executing. Press ^C once or twice to stop waiting for when-statements and after-statements.\033[039m", flush=True)
     try:
         while True:
             sleep(1)  # just waiting for any clicks, when statements, etc


### PR DESCRIPTION
Seems that there is no trivial way to ensure that every single print called is flushed, so i am just adding the minimum where it really is required.

Fixes https://github.com/vivaansinghvi07/dreamberd-interpreter/issues/33.