### PR TITLE
dreamberd file access

### DIFF
--- a/dreamberd/builtin.py
+++ b/dreamberd/builtin.py
@@ -494,6 +494,14 @@ def db_sleep(t: DreamberdNumber) -> None:
         raise NonFormattedError("'sleep' function requires numerical input.")
     sleep(t.value)
 
+def db_read(path: DreamberdString) -> DreamberdString:
+    with open(path.value) as f: s = f.read()
+    return DreamberdString(s)
+
+def db_write(path: DreamberdString, content: DreamberdValue) -> None:
+    content = db_to_string(content).value
+    with open(path.value, "w") as f: f.write(content)
+
 def db_exit() -> None:
     exit()
 
@@ -532,6 +540,8 @@ BUILTIN_FUNCTION_KEYWORDS = {
     "Number": Name("Number", BuiltinFunction(1, db_to_number)),
     "use": Name("use", BuiltinFunction(1, db_signal)),
     "sleep": Name("sleep", BuiltinFunction(1, db_sleep)),
+    "read": Name("read", BuiltinFunction(-1, db_read)),
+    "write": Name("write", BuiltinFunction(-1, db_write)),
 }
 BUILTIN_VALUE_KEYWORDS = {
     "true": Name("true", DreamberdBoolean(True)),

--- a/dreamberd/builtin.py
+++ b/dreamberd/builtin.py
@@ -489,18 +489,22 @@ def db_signal(starting_value: DreamberdValue) -> DreamberdValue:
         obj.value = setter_val
     return BuiltinFunction(1, signal_func)
 
-def db_sleep(t: DreamberdNumber) -> None:
+def db_sleep(t: DreamberdValue) -> None:
     if not isinstance(t, DreamberdNumber):
         raise NonFormattedError("'sleep' function requires numerical input.")
     sleep(t.value)
 
-def db_read(path: DreamberdString) -> DreamberdString:
+def db_read(path: DreamberdValue) -> DreamberdString:
+    if not isinstance(path, DreamberdString):
+        raise NonFormattedError("'read' function requires argument to be a string")
     with open(path.value) as f: s = f.read()
     return DreamberdString(s)
 
-def db_write(path: DreamberdString, content: DreamberdValue) -> None:
-    content = db_to_string(content).value
-    with open(path.value, "w") as f: f.write(content)
+def db_write(path: DreamberdValue, content: DreamberdValue) -> None:
+    if not isinstance(path, DreamberdString):
+        raise NonFormattedError("'read' function requires argument to be a string")
+    content_str = db_to_string(content).value
+    with open(path.value, "w") as f: f.write(content_str)
 
 def db_exit() -> None:
     exit()


### PR DESCRIPTION
I didn't find any way to read and write external files as strings in this interpreter's builtin functions. If the dreamberd interpreter interpreter or any other compiler infrastructure is to be made, this is kind of necessary.

I'm not sure if this is the best way to go about doing this, but it's pretty simple and seems to work.